### PR TITLE
Remove redundant resource_name.

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -6,7 +6,6 @@
 # Copyright (c) 2015, Parallels IP Holdings GmbH
 #
 
-resource_name :log_forward
 provides :log_forward
 
 actions :create


### PR DESCRIPTION
Fixes compatibility issue with Chef 11. Should resolve #10.
