### PR TITLE
Use the `Chef::ResourceResolver#resolve` method on modern Chef client.

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -6,7 +6,7 @@
 # Copyright (c) 2015, Parallels IP Holdings GmbH
 #
 
-provides :log_forward if ::Chef::Version.new(::Chef::VERSION).major >= 12
+provides :log_forward if defined?(provides)
 
 use_inline_resources if defined?(use_inline_resources)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,12 @@ package 'logstash-forwarder'
 
 ruby_block 'get log_forward resources' do
   block do
-    files = run_context.resource_collection.select { |r| r.is_a?(Chef::Resource::LogstashForwarder) }.map { |r| { paths: r.paths, fields: r.fields } }
+    klass = if defined?(Chef::ResourceResolver)
+      r = Chef::ResourceResolver
+      r.respond_to?(:resolve) && r.resolve(:logstash_forwarder)
+    end
+    klass ||= Chef::Resource::LogstashForwarder
+    files = run_context.resource_collection.select { |r| r.is_a?(klass) }.map { |r| { paths: r.paths, fields: r.fields } }
     node.set['logstash-forwarder']['files'] = files
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -6,10 +6,10 @@
 # Copyright (c) 2015, Parallels IP Holdings GmbH
 #
 
-provides :log_forward
+provides :log_forward if defined?(provides)
 
 actions :create
-default_action :create
+default_action :create if defined?(default_action)
 
 attribute :paths, kind_of: Array, required: true
 attribute :fields, kind_of: Hash, default: {}, required: true


### PR DESCRIPTION
This is to make sure that from Chef client 13 onwards there will be not problem
with accessing the instance of `Chef::Resource::LogstashForwarder` to collect
values from attributes, and the warning about deprecation will be gone.
